### PR TITLE
Fix for failing PrefixMap.remove() and TermMap.remove()

### DIFF
--- a/lib/Profile.js
+++ b/lib/Profile.js
@@ -23,7 +23,7 @@ api.PrefixMap.prototype.set = function(prefix, uri){
 	if(prefix.slice(-1)==":") prefix=prefix.slice(0, -1);
 	this[prefix] = uri;
 }
-api.PrefixMap.prototype.remove = function(toResolve){
+api.PrefixMap.prototype.remove = function(prefix){
 	if(Object.hasOwnProperty.call(this, prefix)) delete this[prefix];
 }
 api.PrefixMap.prototype.resolve = function(curie){
@@ -63,7 +63,7 @@ api.TermMap.prototype.set = function(term, uri){
 	this[term] = uri;
 }
 api.TermMap.prototype.remove = function(term){
-	if(Object.hasOwnProperty.call(this, prefix)) delete this[prefix];
+	if(Object.hasOwnProperty.call(this, term)) delete this[term];
 }
 api.TermMap.prototype.resolve = function(term){
 	if(Object.hasOwnProperty.call(this, term)) return this[term];


### PR DESCRIPTION
Parameter name in method signature did not match variable names used within the method.