### PR TITLE
Change builtin's prototype property definitions to be writable

### DIFF
--- a/lib/Builtins.js
+++ b/lib/Builtins.js
@@ -8,7 +8,7 @@ var rdffirst = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#first';
 var rdfrest = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#rest';
 function xsdns(v){ return 'http://www.w3.org/2001/XMLSchema#'+v; }
 
-function _(v) { return { writable:false, configurable:false, enumerable:false, value:v } }
+function _(v) { return { writable:true, configurable:false, enumerable:false, value:v } }
 function _getter(v) { return { configurable:false, enumerable:false, get:v } }
 function prop(p,l) {
 	if(p == 'a') return 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';


### PR DESCRIPTION
[edit: commit ate my # comments - adding back in this message]

When using the builtins previously we were creating all prototype
properties as writable:false.

Doing this on the Object prototype causes failures in existing
third-party code.

Due to strict mode, with builtins enabled, the following code
causes  an error to be thrown:-

var o = {}
o.ref = null

This breaks the principle of least surprise.

I originally ran into the problem when including the library in a
Meteor project.

To reproduce:

meteor create myproject
cd myproject
meteor npm install

meteor npm install --save rdf

meteor

// Then in a new window, go to server/main.js 
// and add the following
var rdf = require('rdf')
rdf.setBuiltins()
console.log(rdf)

In the window running Meteor, there will be an exception from
deep inside Node, caused by the call to console.log().

The offending code was simply assigning some properties to an
object created by Object.create(null) - the root cause of the
problem is that strict mode causes an error to be thrown if
code tries to assign to an existing property that is not writable.

This change allows us to play nicely with others a little more
when using the builtins - we shouldn't block others when they
are simply using Object in a normal fashion.