### PR TITLE
Improve PrefixMap.shrink() - shrink to longest-matching namespace

### DIFF
--- a/lib/Profile.js
+++ b/lib/Profile.js
@@ -11,7 +11,8 @@ api.SCHEME_MATCH = new RegExp("^[a-z0-9-.+]+:", "i");
  * Implements PrefixMap http://www.w3.org/TR/2011/WD-rdf-interfaces-20110510/#idl-def-PrefixMap
  */
 api.PrefixMap = function PrefixMap(){
-	
+	Object.defineProperty(this, '_rev', {value:{}});
+	Object.defineProperty(this, '_nscache', {value:null, writable:true});
 }
 api.PrefixMap.prototype.get = function(prefix){
 	// strip a trailing ":"
@@ -21,10 +22,16 @@ api.PrefixMap.prototype.get = function(prefix){
 api.PrefixMap.prototype.set = function(prefix, uri){
 	// strip a trailing ":"
 	if(prefix.slice(-1)==":") prefix=prefix.slice(0, -1);
+	if(prefix.charAt(0)=="_") return;
 	this[prefix] = uri;
+	this._rev[uri] = prefix;
+	this._nscache=null;
 }
-api.PrefixMap.prototype.remove = function(toResolve){
-	if(Object.hasOwnProperty.call(this, prefix)) delete this[prefix];
+api.PrefixMap.prototype.remove = function(prefix){
+	if(Object.hasOwnProperty.call(this, prefix)) {
+		var uri = this[prefix]; delete this._rev[uri]; delete this[prefix];
+		this._nscache=null;
+    }
 }
 api.PrefixMap.prototype.resolve = function(curie){
 	var index = curie.indexOf(":");
@@ -37,9 +44,10 @@ api.PrefixMap.prototype.resolve = function(curie){
 	return resolved.toString();
 }
 api.PrefixMap.prototype.shrink = function(uri) {
-	for(prefix in this)
-		if(Object.hasOwnProperty.call(this, prefix) && uri.substr(0,this[prefix].length)==this[prefix])
-			return prefix + ':' + uri.slice(this[prefix].length);
+	if(!this._nscache) this._nscache = Object.keys(this._rev).sort(function(a,b){return b.length-a.length});
+	for(var ns of this._nscache)
+		if(ns.length<uri.length && uri.substr(0,ns.length)==ns)
+		return this._rev[ns]+":"+uri.slice(ns.length);
 	return uri;
 }
 api.PrefixMap.prototype.setDefault = function(uri){


### PR DESCRIPTION
Addresses issue #9

I believe this is a better fix than the currently proposed patch.

I changed shrink() to match against a list of namespace IRIs, sorted
by length. If a substring match is found, I then do a reverse-lookup
from IRI to prefix.

The sorted list is only generated during shrink() if it does not
already exist: it is cached between calls. Calls to set() or
remove() nullify the cached list.

Two new properties have been added to PrefixMap for all this: _rev
which holds a reverse-lookup from namespace IRI to prefix, and
_nscache which holds the list of namespace IRIs, sorted by length.

Additionally, in set() I now silently ignore prefixes beginning
with '_' (an underscore char - eaten by github), to prevent 
accidently clobbering of the new properties.
Which, albeit a subtle behaviour change (which I'm not too keen
on), shouldn't matter anyway because in Turtle, SPARQL, et al.,
underscore is not a valid start character for a prefix name.