### PR TITLE
Fix typo in RDFEnvironment prototype creation (iterable->enumerable)

### DIFF
--- a/lib/RDFEnvironment.js
+++ b/lib/RDFEnvironment.js
@@ -16,7 +16,7 @@ exports.RDFEnvironment = function RDFEnvironment(){
 	Profile.call(this);
 	loadRequiredPrefixMap(this);
 }
-exports.RDFEnvironment.prototype = Object.create(Profile.prototype, {constructor:{value:exports.RDFEnvironment, iterable:false}});
+exports.RDFEnvironment.prototype = Object.create(Profile.prototype, {constructor:{value:exports.RDFEnvironment, enumerable:false}});
 exports.RDFEnvironment.prototype.createBlankNode = function(){
 	return new BlankNode;
 }


### PR DESCRIPTION
'iterable' is not a valid property in an object property definition.