### PR TITLE
Fix global escape of variable in TermMap.shrink()

### DIFF
--- a/lib/Profile.js
+++ b/lib/Profile.js
@@ -70,7 +70,7 @@ api.TermMap.prototype.resolve = function(term){
 	return null;
 }
 api.TermMap.prototype.shrink = function(uri){
-	for(term in this)
+	for(var term in this)
 		if(Object.hasOwnProperty.call(this, term) && uri==this[term])
 			return term;
 	return uri;


### PR DESCRIPTION
for (foo in bar) 
should be 
for (var foo in bar)