### PR TITLE
Fix global escape of variable in PrefixMap.shrink()

### DIFF
--- a/lib/Profile.js
+++ b/lib/Profile.js
@@ -37,7 +37,7 @@ api.PrefixMap.prototype.resolve = function(curie){
 	return resolved.toString();
 }
 api.PrefixMap.prototype.shrink = function(uri) {
-	for(prefix in this)
+	for(var prefix in this)
 		if(Object.hasOwnProperty.call(this, prefix) && uri.substr(0,this[prefix].length)==this[prefix])
 			return prefix + ':' + uri.slice(this[prefix].length);
 	return uri;


### PR DESCRIPTION
This patch/pull request is redundant if you decide to merge
jimsmart:bugfix/prefixmap-resolve-to-longest-match

for (foo in bar) 
should be 
for (var foo in bar)