### PR TITLE
Fix package.json main field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"url": "git://github.com/awwright/node-rdf.git",
 		"web": "https://github.com/awwright/node-rdf"
 	},
-	"main": "lib/rdf.js",
+	"main": "index.js",
 	"scripts": {
 		"test": "mocha"
 	},


### PR DESCRIPTION
Some JSON-LD tooling we have is using this package through `rdfa` and now Node.js 16+ complains about the `package.json` `main` field.  It looks like it should be `index.js`.  A patch release with this fix would be appreciated.